### PR TITLE
Object file's names were not matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ all: server client
 	make client
 
 server:
-	$(CC) iserver.c -o server.out -lpthread
+	$(CC) iserver.c -o server -lpthread
 
 client:
-	$(CC) -o guiclient.out guiclient.c `pkg-config --libs gtk+-2.0 libvlc` `pkg-config --cflags gtk+-2.0 libvlc`
+	$(CC) -o guiclient guiclient.c `pkg-config --libs gtk+-2.0 libvlc` `pkg-config --cflags gtk+-2.0 libvlc`
 
 clean:
-	rm server.out guiclient.out
+	rm server guiclient


### PR DESCRIPTION
The object files created had .out extension, for which we need to write "./server.out" to run them. And that was not same as what is written in the readme file because readme just says to do "./server" and "./guiclient".